### PR TITLE
support c1 files

### DIFF
--- a/ftdetect/c0-detect.vim
+++ b/ftdetect/c0-detect.vim
@@ -1,2 +1,5 @@
 " place in .vim/ftdetect/
 au BufRead,BufNewFile *.c0             set filetype=c0
+au BufRead,BufNewFile *.h0             set filetype=c0
+au BufRead,BufNewFile *.c1             set filetype=c0
+au BufRead,BufNewFile *.h1             set filetype=c0

--- a/syntax/c0.vim
+++ b/syntax/c0.vim
@@ -104,7 +104,7 @@ syn case match
 
 " c0 annotations
 syntax keyword cAnnoSpec	contained requires ensures loop_invariant assert
-syntax match cAnnoVal		contained "\\\(result\|length\|old\)\|NULL"
+syntax match cAnnoVal		contained "\\\(result\|length\|hastag\)"
 
 if exists("c_comment_strings")
   " A comment can contain cString, cCharacter and cNumber.


### PR DESCRIPTION
We've recently updated our c0 vim configuration files to support h0, h1, and c1 files.
